### PR TITLE
Message for missing optional opm python when running tests

### DIFF
--- a/tests/test_2_coarsening.py
+++ b/tests/test_2_coarsening.py
@@ -7,12 +7,19 @@
 import os
 import pathlib
 import subprocess
+import warnings
 
 OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_2_coarsening.py is only run "
+            "using resdata."
+        )
+    )
 
 testpth: pathlib.Path = pathlib.Path(__file__).parent
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]

--- a/tests/test_3_refinement.py
+++ b/tests/test_3_refinement.py
@@ -7,6 +7,7 @@
 import os
 import pathlib
 import subprocess
+import warnings
 import numpy as np
 from resdata.resfile import ResdataFile
 
@@ -14,7 +15,13 @@ OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_3_refinement.py is only run "
+            "using resdata."
+        )
+    )
 
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 testpth: pathlib.Path = pathlib.Path(__file__).parent

--- a/tests/test_4_submodel.py
+++ b/tests/test_4_submodel.py
@@ -7,6 +7,7 @@
 import os
 import pathlib
 import subprocess
+import warnings
 import numpy as np
 from resdata.resfile import ResdataFile
 
@@ -14,7 +15,13 @@ OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_4_submodel.py is only run "
+            "using resdata."
+        )
+    )
 
 testpth: pathlib.Path = pathlib.Path(__file__).parent
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]

--- a/tests/test_5_transform.py
+++ b/tests/test_5_transform.py
@@ -7,13 +7,20 @@
 import os
 import pathlib
 import subprocess
+import warnings
 from resdata.grid import Grid
 
 OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_5_transform.py is only run "
+            "using resdata."
+        )
+    )
 
 testpth: pathlib.Path = pathlib.Path(__file__).parent
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]

--- a/tests/test_6_segwell_faults.py
+++ b/tests/test_6_segwell_faults.py
@@ -24,6 +24,7 @@ OPERNUM 2 30 38 47 52 2* /
 import os
 import pathlib
 import subprocess
+import warnings
 import numpy as np
 from resdata.resfile import ResdataFile
 
@@ -31,7 +32,13 @@ OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_6_segwell_faults.py is only run "
+            "using resdata."
+        )
+    )
 
 testpth: pathlib.Path = pathlib.Path(__file__).parent
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]

--- a/tests/test_7_transmissibilities.py
+++ b/tests/test_7_transmissibilities.py
@@ -7,13 +7,20 @@
 import os
 import pathlib
 import subprocess
+import warnings
 from resdata.resfile import ResdataFile
 
 OPM = False
 try:
     OPM = bool(__import__("opm"))
 except ImportError:
-    pass
+    warnings.warn(
+        UserWarning(
+            "The optional OPM Python package for postprocessing "
+            "the simulation files is not found; then, test_7_transmissibilities.py is only run "
+            "using resdata."
+        )
+    )
 
 testpth: pathlib.Path = pathlib.Path(__file__).parent
 mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]


### PR DESCRIPTION
This PR adds support to write a warning message when the tests are run and the optional opm Python package is not found, i.e., the tests are run only using the required package resdata.  

Both packages are use to postprocess OPM Flow output files. Differences between the Python opm package and resdata are that while resdata is easier to install in macOS, the opm Python package seems to be faster.