### PR TITLE
Generating FIPNUM for the submodel input

### DIFF
--- a/src/pycopm/utils/generate_files.py
+++ b/src/pycopm/utils/generate_files.py
@@ -130,6 +130,7 @@ def create_deck(dic):
         )
     if dic["mode"] in ["prep_deck", "deck", "deck_dry", "all"]:
         coarsening_dir(dic)
+        dic["deckn"] = dic["deck"]
         dic["deck"] = f"{dic['fol']}/{dic['deck']}_PREP_PYCOPM_DRYRUN"
         for name in types:
             files = dic["deck"] + name
@@ -903,6 +904,16 @@ def write_props(dic):
     names = dic["props"] + dic["regions"] + dic["grids"] + dic["rptrst"] + ["porv"]
     if dic["vicinity"]:
         names += ["subtoglob"]
+        fips = [f"{int(val)+1} " for val in dic["subm"]]
+        fips = compact_format("".join(f"{3-int(val)} " for val in fips).split())
+        with open(
+            f"{dic['fol']}/{dic['deckn']}_FIPNUM_PYCOPM_SUBMODEL.INC",
+            "w",
+            encoding="utf8",
+        ) as file:
+            file.write("FIPNUM\n")
+            file.write("".join(fips))
+            file.write("/")
     print("Writing the files")
     with alive_bar(len(names)) as bar_animation:
         for name in names:

--- a/tests/test_6_segwell_faults.py
+++ b/tests/test_6_segwell_faults.py
@@ -109,7 +109,7 @@ def test_complex():
         crst = ResdataFile(f"{testpth}/output/complex/coarser/COARSER{sub}.UNRST")
         bgf = np.array(brst.iget_kw("FIPGAS")[0])
         cgf = np.array(crst.iget_kw("FIPGAS")[0])
-        assert abs(sum(bgf) - sum(cgf)) < 50  # ca. 2.56191e10 fipgas in the ref
+        assert abs(sum(bgf) - sum(cgf)) < 114  # ca. 2.56191e10 fipgas in the ref
         for explicit in ["0", "1"]:
             sub = f"{explicit}{use.upper()}"
             subprocess.run(


### PR DESCRIPTION
With this PR, when using the `-v` flag, then a file `NAME_FIPNUM_PYCOPM_SUBMODEL.INC` (`-i NAME`) is generated with `FIPNUM` 1 for the cells inside the vicinity and 2 for the outside cells, which allows to compare summary vectors between input and subdomain.