### PR TITLE
Updating the test to use tmp_path and monkeypatch

### DIFF
--- a/.github/workflows/ci_pycopm_ubuntu.yml
+++ b/.github/workflows/ci_pycopm_ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
       
     - name: Run tests
       run: |
-        pytest --cov=pycopm --exitfirst --cov-report term-missing tests/
+        pytest --cov=pycopm --exitfirst --cov-report term-missing --basetemp=test_outputs tests/
 
     - name: Run hello world example
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -162,9 +162,6 @@ cython_debug/
 # macOS
 .DS_Store
 
-# Tests
-/tests/output
-
 # Python environment
 vpycopm/
 
@@ -183,7 +180,7 @@ opm-simulators/
 cssr/
 developing/
 examples/configurations/drogon/drogon_coarser
-output/
+test_outputs/
 playground/
 presentation/
 prototyping/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Contributions are more than welcome using the fork and pull request approach ðŸ™
     1. **black --target-version py312 src/ tests/** (this formats the code)
     1. **pylint src/ tests/** (this analyses the code, and might rise issues that need to be fixed before the pull request)
     1. **mypy --ignore-missing-imports src/ tests/** (this is a static checker, and might rise issues that need to be fixed before the pull request)
-    1. **pytest --cov=pycopm --cov-report term-missing tests/** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
+    1. **pytest --cov=pycopm --cov-report term-missing --basetemp=test_outputs tests/ -n auto** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
     1. **pycopm -i examples/decks/HELLO_WORLD.DATA -c 5,5,1 -m all -o output** (this runs the hello world example, which succeeds if the file output/HELLO_WORLD_PYCOPM.EGRID is created)
     1. **pushd docs & make html** (this generates the documentation, and might rise issues that need to be fixed before the pull request; if the build succeeds and if the contribution changes the documentation, then copy all content from the docs/_build/html/ folder and replace the files in the [_docs_](https://github.com/cssr-tools/pycopm/tree/main/docs) folder)
     * Tip for Linux users: See the [_ci_pycopm_ubuntu.yml_](https://github.com/cssr-tools/pycopm/blob/main/.github/workflows/ci_pycopm_ubuntu.yml) script and the [_Actions_](https://github.com/cssr-tools/pycopm/actions) for installation of pycopm, OPM Flow (binary packages), and dependencies, as well as the execution of the seven previous steps in Ubuntu 24.04 using Python 3.12.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,6 @@ numpydoc<=1.9.0
 mypy<=1.18.2
 pylint<=4.0.0
 pytest-cov<=7.0.0
+pytest-xdist<=3.8.0
 sphinx<=8.2.3
 sphinx-rtd-theme<=3.0.2

--- a/docs/_sources/contributing.rst.txt
+++ b/docs/_sources/contributing.rst.txt
@@ -25,7 +25,7 @@ Contribute to the software
     #. **black --target-version py312 src/ tests/** (this formats the code)
     #. **pylint src/ tests/** (this analyses the code, and might rise issues that need to be fixed before the pull request)
     #. **mypy --ignore-missing-imports src/ tests/** (this is a static checker, and might rise issues that need to be fixed before the pull request)
-    #. **pytest --cov=pycopm --cov-report term-missing tests/** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
+    #. **pytest --cov=pycopm --cov-report term-missing --basetemp=test_outputs tests/ -n auto** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
     #. **pycopm -i examples/decks/HELLO_WORLD.DATA -c 5,5,1 -m all -o output** (this runs the hello world example, which succeeds if the file output/HELLO_WORLD_PYCOPM.EGRID is created)
     #. **pushd docs & make html** (this generates the documentation, and might rise issues that need to be fixed before the pull request; if the build succeeds and if the contribution changes the documentation, then copy all content from the docs/_build/html/ folder and replace the files in the `docs <https://github.com/cssr-tools/pycopm/tree/main/docs>`_ folder)
     

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -108,10 +108,10 @@ documentation about collaborating with pull request; also, looking at previous m
 <blockquote>
 <div><ol class="arabic simple">
 <li><p><strong>pip install -r dev-requirements.txt</strong> (this installs the <a class="reference external" href="https://github.com/cssr-tools/pycopm/blob/main/dev-requirements.txt">dev-requirements.txt</a>)</p></li>
-<li><p><strong>black –target-version py312 src/ tests/</strong> (this formats the code)</p></li>
+<li><p><strong>black --target-version py312 src/ tests/</strong> (this formats the code)</p></li>
 <li><p><strong>pylint src/ tests/</strong> (this analyses the code, and might rise issues that need to be fixed before the pull request)</p></li>
-<li><p><strong>mypy –ignore-missing-imports src/ tests/</strong> (this is a static checker, and might rise issues that need to be fixed before the pull request)</p></li>
-<li><p><strong>pytest –cov=pycopm –cov-report term-missing tests/</strong> (this runs locally the tests, and might rise issues that need to be fixed before the pull request)</p></li>
+<li><p><strong>mypy --ignore-missing-imports src/ tests/</strong> (this is a static checker, and might rise issues that need to be fixed before the pull request)</p></li>
+<li><p><strong>pytest --cov=pycopm --cov-report term-missing --basetemp=test_outputs tests/ -n auto</strong> (this runs locally the tests, and might rise issues that need to be fixed before the pull request)</p></li>
 <li><p><strong>pycopm -i examples/decks/HELLO_WORLD.DATA -c 5,5,1 -m all -o output</strong> (this runs the hello world example, which succeeds if the file output/HELLO_WORLD_PYCOPM.EGRID is created)</p></li>
 <li><p><strong>pushd docs &amp; make html</strong> (this generates the documentation, and might rise issues that need to be fixed before the pull request; if the build succeeds and if the contribution changes the documentation, then copy all content from the docs/_build/html/ folder and replace the files in the <a class="reference external" href="https://github.com/cssr-tools/pycopm/tree/main/docs">docs</a> folder)</p></li>
 </ol>
@@ -119,7 +119,7 @@ documentation about collaborating with pull request; also, looking at previous m
 <p class="admonition-title">Tip</p>
 <p>See the <a class="reference external" href="https://github.com/cssr-tools/pycopm/blob/main/.github/workflows/ci_pycopm_ubuntu.yml">ci_pycopm_ubuntu.yml</a> script and the <a class="reference external" href="https://github.com/cssr-tools/pycopm/actions">Actions</a> for installation of pycopm, OPM Flow (binary packages), and dependencies, as well as the execution of the seven previous steps in Ubuntu 24.04 using Python 3.12.
 For macOS users, see the <a class="reference external" href="https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml">ci_pycopm_macos.yml</a> script and the <a class="reference external" href="https://github.com/cssr-tools/pycopm/actions">OPM-Flow_macOS Actions</a> for installation of pycopm, OPM Flow (source build), and dependencies, as well as running the tests and the hello world example in macOS 26 using Python3.14.
-Note that if you do not add the directory containing the OPM Flow executable to your system’s PATH environment variable (e.g., export PATH=$PATH:/Users/yourname/pycopm/build/opm-simulators/bin), then you can pass this in the execution of the tests and pycopm using the flags <strong>-f/–flow</strong> (see <a class="reference external" href="https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml#L72">this script</a>).</p>
+Note that if you do not add the directory containing the OPM Flow executable to your system’s PATH environment variable (e.g., export PATH=$PATH:/Users/yourname/pycopm/build/opm-simulators/bin), then you can pass this in the execution of the tests and pycopm using the flags <strong>-f/--flow</strong> (see <a class="reference external" href="https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml#L72">this script</a>).</p>
 </div>
 </div></blockquote>
 </li>

--- a/docs/text/contributing.rst
+++ b/docs/text/contributing.rst
@@ -22,17 +22,17 @@ Contribute to the software
 #. In the main repo execute:
 
     #. **pip install -r dev-requirements.txt** (this installs the `dev-requirements.txt <https://github.com/cssr-tools/pycopm/blob/main/dev-requirements.txt>`_)
-    #. **black --target-version py312 src/ tests/** (this formats the code)
+    #. **black \-\-target-version py312 src/ tests/** (this formats the code)
     #. **pylint src/ tests/** (this analyses the code, and might rise issues that need to be fixed before the pull request)
-    #. **mypy --ignore-missing-imports src/ tests/** (this is a static checker, and might rise issues that need to be fixed before the pull request)
-    #. **pytest --cov=pycopm --cov-report term-missing tests/** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
+    #. **mypy \-\-ignore-missing-imports src/ tests/** (this is a static checker, and might rise issues that need to be fixed before the pull request)
+    #. **pytest \-\-cov=pycopm \-\-cov-report term-missing \-\-basetemp=test_outputs tests/ -n auto** (this runs locally the tests, and might rise issues that need to be fixed before the pull request)
     #. **pycopm -i examples/decks/HELLO_WORLD.DATA -c 5,5,1 -m all -o output** (this runs the hello world example, which succeeds if the file output/HELLO_WORLD_PYCOPM.EGRID is created)
     #. **pushd docs & make html** (this generates the documentation, and might rise issues that need to be fixed before the pull request; if the build succeeds and if the contribution changes the documentation, then copy all content from the docs/_build/html/ folder and replace the files in the `docs <https://github.com/cssr-tools/pycopm/tree/main/docs>`_ folder)
     
     .. tip::
         See the `ci_pycopm_ubuntu.yml <https://github.com/cssr-tools/pycopm/blob/main/.github/workflows/ci_pycopm_ubuntu.yml>`_ script and the `Actions <https://github.com/cssr-tools/pycopm/actions>`_ for installation of pycopm, OPM Flow (binary packages), and dependencies, as well as the execution of the seven previous steps in Ubuntu 24.04 using Python 3.12.
         For macOS users, see the `ci_pycopm_macos.yml <https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml>`_ script and the `OPM-Flow_macOS Actions <https://github.com/cssr-tools/pycopm/actions>`_ for installation of pycopm, OPM Flow (source build), and dependencies, as well as running the tests and the hello world example in macOS 26 using Python3.14.
-        Note that if you do not add the directory containing the OPM Flow executable to your system's PATH environment variable (e.g., export PATH=$PATH:/Users/yourname/pycopm/build/opm-simulators/bin), then you can pass this in the execution of the tests and pycopm using the flags **-f/--flow** (see `this script <https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml#L72>`_).
+        Note that if you do not add the directory containing the OPM Flow executable to your system's PATH environment variable (e.g., export PATH=$PATH:/Users/yourname/pycopm/build/opm-simulators/bin), then you can pass this in the execution of the tests and pycopm using the flags **-f/\-\-flow** (see `this script <https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml#L72>`_).
 
 #. Squash your commits into a single commit (see this `nice tutorial <https://gist.github.com/lpranam/4ae996b0a4bc37448dc80356efbca7fa>`_ if you are not familiar with this)
 #. Push your commit and make a pull request

--- a/tests/test_0_main.py
+++ b/tests/test_0_main.py
@@ -3,28 +3,21 @@
 
 """Test the configuration files"""
 
-import os
-import pathlib
+from pathlib import Path
+import shutil
+
 from pycopm.core.pycopm import main
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_main():
+def test_0_main(tmp_path, monkeypatch):
     """See examples/configurations/norne/input.toml"""
-    confi = f"{mainpth}/examples/configurations/norne/input.toml"
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
-        os.system(f"mkdir {testpth}/output/main")
-        os.system(f"cp {confi} {testpth}/output/main/input.toml")
-    elif not os.path.exists(f"{testpth}/output/main"):
-        os.system(f"mkdir {testpth}/output/main")
-        os.system(f"cp {confi} {testpth}/output/main/input.toml")
-    elif not os.path.isfile(f"{testpth}/output/main/input.toml"):
-        os.system(f"cp {confi} {testpth}/output/main/input.toml")
-    os.chdir(f"{testpth}/output/main")
+    monkeypatch.chdir(tmp_path)
+    repo_root = Path(__file__).parents[1]
+    input_config = repo_root / "examples" / "configurations" / "norne" / "input.toml"
+    shutil.copy(input_config, tmp_path / "input.toml")
+    monkeypatch.chdir(tmp_path)
     main()
-    assert os.path.exists(
-        f"{testpth}/output/main/postprocessing/wells/HISTO_DATA_WWPR_E-1H.png"
-    )
+    assert (tmp_path / "postprocessing" / "errors.txt").is_file()
+    assert (
+        tmp_path / "postprocessing" / "wells" / "HISTO_DATA_WWPR_E-1H.png"
+    ).is_file()

--- a/tests/test_1_ert.py
+++ b/tests/test_1_ert.py
@@ -3,19 +3,14 @@
 
 """Test the ert functionality via the configuration file"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_ert(flow):
+def test_1_ert(flow, tmp_path, monkeypatch):
     """See examples/configurations/drogon/input.toml"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
-    os.chdir(f"{testpth}/output")
-    confi = f"{mainpth}/examples/configurations/drogon/input.toml"
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
+    confi = f"{repo_root}/examples/configurations/drogon/input.toml"
     subprocess.run(["pycopm", "-i", confi, "-o", "ert", "-f", flow], check=True)
-    assert os.path.exists(f"{testpth}/output/ert/postprocessing/hm_missmatch.png")
+    assert (tmp_path / "ert" / "postprocessing" / "hm_missmatch.png").is_file()

--- a/tests/test_2_coarsening.py
+++ b/tests/test_2_coarsening.py
@@ -1,46 +1,33 @@
 # SPDX-FileCopyrightText: 2024-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801
 
 """Test the generic coarsening functionality"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_coarsening(flow):
+def test_2_coarsening(flow, tmp_path, monkeypatch):
     """See examples/decks/HELLO_WORLD.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     sub = "FINER"
     subprocess.run(
         [
             "pycopm",
             "-f",
             flow,
-            "-f",
-            flow,
             "-c",
             "5,5,1",
             "-i",
-            f"{mainpth}/examples/decks/HELLO_WORLD.DATA",
-            "-o",
-            f"{testpth}/output/coarser",
+            f"{repo_root}/examples/decks/HELLO_WORLD.DATA",
             "-m",
             "prep",
         ],
         check=True,
     )
-    assert os.path.exists(
-        f"{testpth}/output/coarser/HELLO_WORLD_PREP_PYCOPM_DRYRUN.INIT"
-    )
-    assert os.path.exists(
-        f"{testpth}/output/coarser/HELLO_WORLD_PREP_PYCOPM_DRYRUN.EGRID"
-    )
+    assert (tmp_path / "HELLO_WORLD_PREP_PYCOPM_DRYRUN.INIT").is_file()
+    assert (tmp_path / "HELLO_WORLD_PREP_PYCOPM_DRYRUN.EGRID").is_file()
     for ahow in ["max", "min", "mode"]:
         for nhow in ["max", "min", "mode"]:
             for show in ["max", "min", "mean", "pvmean"]:
@@ -50,9 +37,7 @@ def test_coarsening(flow):
                         "-f",
                         flow,
                         "-i",
-                        f"{mainpth}/examples/decks/HELLO_WORLD.DATA",
-                        "-o",
-                        f"{testpth}/output/coarser",
+                        f"{repo_root}/examples/decks/HELLO_WORLD.DATA",
                         "-c",
                         "5,5,1",
                         "-m",
@@ -66,19 +51,15 @@ def test_coarsening(flow):
                     ],
                     check=True,
                 )
-                assert os.path.exists(
-                    f"{testpth}/output/coarser/HELLO_WORLD_PYCOPM.DATA"
-                )
-                os.system(f"rm {testpth}/output/coarser/HELLO_WORLD_PYCOPM.DATA")
+                assert (tmp_path / "HELLO_WORLD_PYCOPM.DATA").is_file()
+                subprocess.run(["rm", "HELLO_WORLD_PYCOPM.DATA"], check=True)
     subprocess.run(
         [
             "pycopm",
             "-f",
             flow,
             "-i",
-            f"{mainpth}/examples/decks/HELLO_WORLD.DATA",
-            "-o",
-            f"{testpth}/output/coarser",
+            f"{repo_root}/examples/decks/HELLO_WORLD.DATA",
             "-m",
             "deck_dry",
             "-p",
@@ -94,17 +75,15 @@ def test_coarsening(flow):
         ],
         check=True,
     )
-    assert os.path.exists(f"{testpth}/output/coarser/{sub}.INIT")
-    assert os.path.exists(f"{testpth}/output/coarser/{sub}.EGRID")
+    assert (tmp_path / f"{sub}.INIT").is_file()
+    assert (tmp_path / f"{sub}.EGRID").is_file()
     subprocess.run(
         [
             "pycopm",
             "-f",
             flow,
             "-i",
-            f"{mainpth}/examples/decks/HELLO_WORLD.DATA",
-            "-o",
-            f"{testpth}/output/coarser",
+            f"{repo_root}/examples/decks/HELLO_WORLD.DATA",
             "-c",
             "1,5,1",
             "-m",
@@ -116,17 +95,15 @@ def test_coarsening(flow):
         ],
         check=True,
     )
-    assert os.path.exists(f"{testpth}/output/coarser/TRANS{sub}.INIT")
-    assert os.path.exists(f"{testpth}/output/coarser/TRANS{sub}.EGRID")
+    assert (tmp_path / f"TRANS{sub}.INIT").is_file()
+    assert (tmp_path / f"TRANS{sub}.EGRID").is_file()
     subprocess.run(
         [
             "pycopm",
             "-f",
             flow,
             "-i",
-            f"{mainpth}/examples/decks/HELLO_WORLD.DATA",
-            "-o",
-            f"{testpth}/output/coarser",
+            f"{repo_root}/examples/decks/HELLO_WORLD.DATA",
             "-c",
             "5,1,4",
             "-m",
@@ -138,5 +115,5 @@ def test_coarsening(flow):
         ],
         check=True,
     )
-    assert os.path.exists(f"{testpth}/output/coarser/TRANS2{sub}.INIT")
-    assert os.path.exists(f"{testpth}/output/coarser/TRANS2{sub}.EGRID")
+    assert (tmp_path / f"TRANS2{sub}.INIT").is_file()
+    assert (tmp_path / f"TRANS2{sub}.EGRID").is_file()

--- a/tests/test_3_refinement.py
+++ b/tests/test_3_refinement.py
@@ -1,33 +1,26 @@
 # SPDX-FileCopyrightText: 2025-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801
 
 """Test the generic refinement functionality"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 import numpy as np
 from opm.io.ecl import EclFile as OpmFile
 
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
-testpth: pathlib.Path = pathlib.Path(__file__).parent
 
-
-def test_refinement(flow):
+def test_3_refinement(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL2.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    monkeypatch.chdir(tmp_path)
+    repo_root = Path(__file__).parents[1]
     sub = "FINER"
     subprocess.run(
         [
             "pycopm",
+            "-i",
+            f"{repo_root}/examples/decks/MODEL2.DATA",
             "-f",
             flow,
-            "-i",
-            f"{mainpth}/examples/decks/MODEL2.DATA",
-            "-o",
-            f"{testpth}/output/finer",
             "-g",
             "2,4,8",
             "-l",
@@ -39,9 +32,8 @@ def test_refinement(flow):
         ],
         check=True,
     )
-    assert os.path.exists(f"{testpth}/output/finer/{sub}.INIT")
-    assert os.path.exists(f"{testpth}/output/finer/{sub}.EGRID")
-    os.chdir(f"{testpth}/output/finer")
+    assert (tmp_path / f"{sub}.INIT").is_file()
+    assert (tmp_path / f"{sub}.EGRID").is_file()
     porv = np.array(OpmFile(f"{sub}.INIT")["PORV"])
     assert abs(np.sum(porv) - 6506.25) < 1e-4
     assert np.sum(porv > 0) == 2430

--- a/tests/test_4_submodel.py
+++ b/tests/test_4_submodel.py
@@ -1,59 +1,48 @@
 # SPDX-FileCopyrightText: 2025-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801
 
 """Test the generic submodel functionality"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 import numpy as np
 from opm.io.ecl import EclFile as OpmFile
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_submodel(flow):
+def test_4_submodel(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL0.DATA and MODEL1.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     for i in range(2):
         sub = f"MODEL{i}_FINER"
-        os.chdir(f"{testpth}/output")
         subprocess.run(
             [
                 "pycopm",
-                "-f",
-                flow,
                 "-i",
-                f"{mainpth}/examples/decks/MODEL{i}.DATA",
-                "-o",
-                f"{testpth}/output/submodel",
+                f"{repo_root}/examples/decks/MODEL{i}.DATA",
                 "-g",
                 "4,4,3",
-                "-m",
-                "all",
                 "-w",
                 sub,
+                "-m",
+                "all",
                 "-l",
                 sub,
+                "-f",
+                flow,
             ],
             check=True,
         )
-        assert os.path.exists(f"{testpth}/output/submodel/{sub}.INIT")
-        assert os.path.exists(f"{testpth}/output/submodel/{sub}.EGRID")
-        os.chdir(f"{testpth}/output/submodel")
+        assert (tmp_path / f"{sub}.INIT").is_file()
+        assert (tmp_path / f"{sub}.EGRID").is_file()
         for j in [1, 3, 4]:
             subprocess.run(
                 [
                     "pycopm",
-                    "-f",
-                    flow,
                     "-i",
                     f"{sub}.DATA",
-                    "-o",
-                    ".",
+                    "-f",
+                    flow,
                     "-v",
                     "xypolygon [3,7.5] [7.5,3] [12,7.5] [7.5,12] [3,7.5]",
                     "-m",

--- a/tests/test_5_transform.py
+++ b/tests/test_5_transform.py
@@ -1,22 +1,17 @@
 # SPDX-FileCopyrightText: 2025-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801
 
 """Test the generic affine transformation functionality"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 from opm.io.ecl import EGrid as OpmGrid
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_transform(flow):
+def test_5_transform(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL0.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     flags = ["translate", "scale", "rotatexy", "rotatexz", "rotateyz"]
     values = ["[5,-3,2]", "[2,.5,4]", "45", "-10", "15"]
     checks = [3, 4, 1, 3.5899, 4.848]
@@ -25,12 +20,10 @@ def test_transform(flow):
         subprocess.run(
             [
                 "pycopm",
+                "-i",
+                f"{repo_root}/examples/decks/MODEL0.DATA",
                 "-f",
                 flow,
-                "-i",
-                f"{mainpth}/examples/decks/MODEL0.DATA",
-                "-o",
-                f"{testpth}/output/transform",
                 "-d",
                 f"{flag} {val}",
                 "-m",
@@ -42,9 +35,9 @@ def test_transform(flow):
             ],
             check=True,
         )
-        assert os.path.exists(f"{testpth}/output/transform/{sub}.INIT")
-        assert os.path.exists(f"{testpth}/output/transform/{sub}.EGRID")
-        grid = OpmGrid(f"{testpth}/output/transform/{sub}.EGRID")
+        assert (tmp_path / f"{sub}.INIT").is_file()
+        assert (tmp_path / f"{sub}.EGRID").is_file()
+        grid = OpmGrid(f"{sub}.EGRID")
         dim = grid.dimension
         zcoord = grid.xyz_from_ijk(dim[0] - 1, dim[1] - 1, dim[2] - 1)[-1][-1]
         assert abs(zcoord - check) < 1e-2

--- a/tests/test_6_segwell_faults.py
+++ b/tests/test_6_segwell_faults.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801,R0914
+# pylint: disable=R0914
 
 """
 Test on a complex model with a segmented well and faults.
@@ -21,38 +21,32 @@ OPERNUM 2 30 38 47 52 2* /
 /
 """
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 import numpy as np
 from opm.io.ecl import EclFile as OpmFile
 from opm.io.ecl import ERst as OpmRestart
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_complex(flow):
+def test_6_segwell_faults(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL3.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     subprocess.run(
         [
             flow,
-            f"{mainpth}/examples/decks/MODEL3.DATA",
-            f"--output-dir={testpth}/output/complex/reference",
+            f"{repo_root}/examples/decks/MODEL3.DATA",
+            f"--output-dir={tmp_path}/reference",
         ],
         check=True,
     )
     subprocess.run(
         [
             "pycopm",
+            "-i",
+            f"{repo_root}/examples/decks/MODEL3.DATA",
             "-f",
             flow,
-            "-o",
-            f"{testpth}/output/complex",
-            "-i",
-            f"{mainpth}/examples/decks/MODEL3.DATA",
             "-x",
             "0,2,0,2,0,0,0,0,0,0",
             "-z",
@@ -72,24 +66,24 @@ def test_complex(flow):
         ],
         check=True,
     )
-    assert os.path.exists(f"{testpth}/output/complex/COARSER.INIT")
-    assert os.path.exists(f"{testpth}/output/complex/COARSER.EGRID")
+    assert (tmp_path / "COARSER.INIT").is_file()
+    assert (tmp_path / "COARSER.EGRID").is_file()
     subprocess.run(
         [
             flow,
-            f"{testpth}/output/complex/COARSER.DATA",
-            f"--output-dir={testpth}/output/complex/coarser",
+            "COARSER.DATA",
+            f"--output-dir={tmp_path}/coarser",
         ],
         check=True,
     )
-    bini = OpmFile(f"{testpth}/output/complex/reference/MODEL3.INIT")
-    cini = OpmFile(f"{testpth}/output/complex/coarser/COARSER.INIT")
+    bini = OpmFile("reference/MODEL3.INIT")
+    cini = OpmFile("coarser/COARSER.INIT")
     bpv = np.array(bini["PORV"])
     cpv = np.array(cini["PORV"])
     assert abs(np.sum(bpv) - np.sum(cpv)) < 50  # ca. 4.61992e8 porv in the ref
     assert np.sum(cpv > 0) == 255
-    brst = OpmRestart(f"{testpth}/output/complex/reference/MODEL3.UNRST")
-    crst = OpmRestart(f"{testpth}/output/complex/coarser/COARSER.UNRST")
+    brst = OpmRestart("reference/MODEL3.UNRST")
+    crst = OpmRestart("coarser/COARSER.UNRST")
     bgf = np.array(brst["FIPGAS", 0])
     cgf = np.array(crst["FIPGAS", 0])
     assert abs(np.sum(bgf) - np.sum(cgf)) < 50  # ca. 2.56191e10 fipgas in the ref
@@ -97,14 +91,12 @@ def test_complex(flow):
         subprocess.run(
             [
                 "pycopm",
-                "-f",
-                flow,
-                "-o",
-                f"{testpth}/output/complex",
                 "-i",
-                f"{mainpth}/examples/decks/MODEL3.DATA",
+                f"{repo_root}/examples/decks/MODEL3.DATA",
                 "-g",
                 "2,2,2",
+                "-f",
+                flow,
                 "-w",
                 f"FINER{sub}",
                 "-l",
@@ -118,21 +110,21 @@ def test_complex(flow):
             ],
             check=True,
         )
-        assert os.path.exists(f"{testpth}/output/complex/FINER{sub}.INIT")
-        assert os.path.exists(f"{testpth}/output/complex/FINER{sub}.EGRID")
+        assert (tmp_path / f"FINER{sub}.INIT").is_file()
+        assert (tmp_path / f"FINER{sub}.EGRID").is_file()
         subprocess.run(
             [
                 flow,
-                f"{testpth}/output/complex/FINER{sub}.DATA",
-                f"--output-dir={testpth}/output/complex/finer",
+                f"FINER{sub}.DATA",
+                "--output-dir=finer",
             ],
             check=True,
         )
-        rini = OpmFile(f"{testpth}/output/complex/finer/FINER{sub}.INIT")
+        rini = OpmFile(f"finer/FINER{sub}.INIT")
         rpv = np.array(rini["PORV"])
         assert abs(np.sum(bpv) - np.sum(rpv)) < 50  # ca. 4.61992e8 porv in the ref
         assert np.sum(rpv > 0) == 22896
-        rrst = OpmRestart(f"{testpth}/output/complex/finer/FINER{sub}.UNRST")
+        rrst = OpmRestart(f"finer/FINER{sub}.UNRST")
         rgf = np.array(rrst["FIPGAS", 0])
         assert abs(np.sum(bgf) - np.sum(rgf)) < 50  # ca. 2.56191e10 fipgas in the ref
     for i, val in enumerate(
@@ -141,14 +133,12 @@ def test_complex(flow):
         subprocess.run(
             [
                 "pycopm",
-                "-f",
-                flow,
-                "-o",
-                f"{testpth}/output/complex",
                 "-i",
-                f"{mainpth}/examples/decks/MODEL3.DATA",
+                f"{repo_root}/examples/decks/MODEL3.DATA",
                 "-v",
                 f"A4 {val}",
+                "-f",
+                flow,
                 "-w",
                 f"SUBMODEL{i}",
                 "-l",
@@ -160,10 +150,10 @@ def test_complex(flow):
             ],
             check=True,
         )
-        assert os.path.exists(f"{testpth}/output/complex/SUBMODEL{i}.INIT")
-        assert os.path.exists(f"{testpth}/output/complex/SUBMODEL{i}.EGRID")
-        bini = OpmFile(f"{testpth}/output/complex/reference/MODEL3.INIT")
-        cini = OpmFile(f"{testpth}/output/complex/SUBMODEL{i}.INIT")
+        assert (tmp_path / f"SUBMODEL{i}.INIT").is_file()
+        assert (tmp_path / f"SUBMODEL{i}.EGRID").is_file()
+        bini = OpmFile("reference/MODEL3.INIT")
+        cini = OpmFile(f"SUBMODEL{i}.INIT")
         bpv = np.array(bini["PORV"])
         cpv = np.array(cini["PORV"])
         assert abs(np.sum(bpv) - np.sum(cpv)) < 1  # ca. 4.61992e8 porv in the ref

--- a/tests/test_7_transmissibilities.py
+++ b/tests/test_7_transmissibilities.py
@@ -1,23 +1,19 @@
 # SPDX-FileCopyrightText: 2025-2026 NORCE Research AS
 # SPDX-License-Identifier: GPL-3.0
-# pylint: disable=R0801,R0914
+# pylint: disable=R0914
 
 """Test the coarsening by transmissibilities"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 import numpy as np
 from opm.io.ecl import EclFile as OpmFile
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_transmissibilities(flow):
+def test_7_transmissibilities(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL4.DATA and MODEL5.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     values = [
         [696.14886, 774.826, 5008.1323, 13739.814453],
         [696.14886, 774.826, 0, 13739.814453],
@@ -26,28 +22,26 @@ def test_transmissibilities(flow):
         subprocess.run(
             [
                 "pycopm",
-                "-f",
-                flow,
-                "-o",
-                f"{testpth}/output/transmissibilities",
                 "-i",
-                f"{mainpth}/examples/decks/MODEL4.DATA",
+                f"{repo_root}/examples/decks/MODEL4.DATA",
                 "-z",
                 "1:30,31:56,57:111,112:116,117:217",
                 "-w",
                 f"COARSER{sub}",
+                "-f",
+                flow,
+                "-a",
+                "max",
                 "-l",
                 f"C0{sub}",
                 "-t",
                 sub,
-                "-a",
-                "max",
                 "-m",
                 "all",
             ],
             check=True,
         )
-        init = OpmFile(f"{testpth}/output/transmissibilities/COARSER{sub}.INIT")
+        init = OpmFile(f"COARSER{sub}.INIT")
         for j, n in enumerate(["X", "Y", "Z", "NNC"]):
             assert (
                 abs(np.sum(np.array(init[f"TRAN{n}"])) - values[i][j]) < 1e-5
@@ -55,12 +49,8 @@ def test_transmissibilities(flow):
         subprocess.run(
             [
                 "pycopm",
-                "-f",
-                flow,
-                "-o",
-                f"{testpth}/output/transmissibilities",
                 "-i",
-                f"{mainpth}/examples/decks/MODEL5.DATA",
+                f"{repo_root}/examples/decks/MODEL5.DATA",
                 "-z",
                 "1:2",
                 "-w",
@@ -71,14 +61,15 @@ def test_transmissibilities(flow):
                 "2",
                 "-a",
                 "max",
+                "-f",
+                flow,
                 "-m",
                 "all",
             ],
             check=True,
         )
-        ref = "MODEL5_PREP_PYCOPM_DRYRUN.INIT"
-        init_ref = OpmFile(f"{testpth}/output/transmissibilities/{ref}")
-        init = OpmFile(f"{testpth}/output/transmissibilities/COARSER_MODEL5.INIT")
+        init_ref = OpmFile("MODEL5_PREP_PYCOPM_DRYRUN.INIT")
+        init = OpmFile("COARSER_MODEL5.INIT")
         assert (
             abs(init["TRANX"][0] - 2 * init_ref["TRANX"][0]) < 1e-5
         ), "Issue in TRANX with MODEL5 (NNCTRAN[0])"

--- a/tests/test_8_dual.py
+++ b/tests/test_8_dual.py
@@ -3,30 +3,24 @@
 
 """Test the dual coarsening, i.e., splitting net and non-net cells"""
 
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 import numpy as np
 from opm.io.ecl import EclFile as OpmFile
 from opm.io.ecl import ERst as OpmRestart
 
-testpth: pathlib.Path = pathlib.Path(__file__).parent
-mainpth: pathlib.Path = pathlib.Path(__file__).parents[1]
 
-
-def test_dual(flow):
+def test_8_dual(flow, tmp_path, monkeypatch):
     """See examples/decks/MODEL6.DATA"""
-    if not os.path.exists(f"{testpth}/output"):
-        os.system(f"mkdir {testpth}/output")
+    repo_root = Path(__file__).parents[1]
+    monkeypatch.chdir(tmp_path)
     subprocess.run(
         [
             "pycopm",
+            "-i",
+            f"{repo_root}/examples/decks/MODEL6.DATA",
             "-f",
             flow,
-            "-o",
-            f"{testpth}/output/dual",
-            "-i",
-            f"{mainpth}/examples/decks/MODEL6.DATA",
             "-z",
             "1:4",
             "-w",
@@ -44,26 +38,26 @@ def test_dual(flow):
     subprocess.run(
         [
             flow,
-            f"{testpth}/output/dual/DUAL.DATA",
+            "DUAL.DATA",
         ],
         check=True,
     )
     subprocess.run(
         [
             flow,
-            f"{mainpth}/examples/decks/MODEL6.DATA",
-            f"--output-dir={testpth}/output/dual",
+            f"{repo_root}/examples/decks/MODEL6.DATA",
+            f"--output-dir={tmp_path}",
         ],
         check=True,
     )
-    initr = OpmFile(f"{testpth}/output/dual/MODEL6.INIT")
-    initd = OpmFile(f"{testpth}/output/dual/DUAL.INIT")
+    initr = OpmFile("MODEL6.INIT")
+    initd = OpmFile("DUAL.INIT")
     assert (
         abs(np.sum(np.array(initr["PORV"])) - np.sum(np.array(initd["PORV"]))) < 1e-12
     ), "Issue with PORV and dual"
     assert (len(initd["PORV"])) == 24, "Issue with dimensions of the dual model"
-    unrstr = OpmRestart(f"{testpth}/output/dual/MODEL6.UNRST")
-    unrstd = OpmRestart(f"{testpth}/output/dual/DUAL.UNRST")
+    unrstr = OpmRestart("MODEL6.UNRST")
+    unrstd = OpmRestart("DUAL.UNRST")
     assert (
         abs(unrstr["PRESSURE", 1][7,] - unrstd["PRESSURE", 1][7]) < 1e-1
     ), "Issue with the dual transsmissibility"


### PR DESCRIPTION
## Description
Updating the tests, such that the output folder can be selected using the  `--basetemp`, and allowing to run them even in parallel using the `-n` flag, i.e.,

`pytest --cov=pycopm --cov-report term-missing --basetemp=test_outputs tests/ -n auto`

Relevantto https://github.com/cssr-tools/pycopm/issues/87, where the tests are run via docker.

PR part of the JOSS review https://github.com/openjournals/joss-reviews/issues/10124