### PR TITLE
Fixing observed timeout during JOSS review

### DIFF
--- a/.github/workflows/ci_pycopm_ubuntu.yml
+++ b/.github/workflows/ci_pycopm_ubuntu.yml
@@ -9,39 +9,43 @@ on:
 jobs:
   run-pycopm-local:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:26.04
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.12
+    - name: Install system dependencies
+      run: |
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          python3 python3-pip python3-venv \
+          build-essential git curl ca-certificates \
+          software-properties-common \
+          octave \
+          mpi-default-bin \
+          freeglut3-dev \
+          libhdf5-dev
+
+        ln -s /usr/bin/python3 /usr/bin/python || true
     
     - name: Install Flow Simulator
       run: |
-        sudo apt-get update
-        sudo apt-get install software-properties-common
-        sudo apt-add-repository ppa:opm/ppa
-        sudo apt-get update
-        sudo apt-get install mpi-default-bin
-        sudo apt-get install libopm-simulators-bin
+        apt-get update
+        apt-add-repository ppa:opm/ppa
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y libopm-simulators-bin
 
-    - name: Install ert dependency
+    - name: Install python requirements
       run: |
-        sudo apt-get install freeglut3-dev
-        
-    - name: Install dependecies
-      run: |
+        python3 -m venv vpycopm
+        . vpycopm/bin/activate
+        echo "$PWD/vpycopm/bin" >> $GITHUB_PATH
         pip install --upgrade pip setuptools wheel
-        pip install -r dev-requirements.txt
-        
-    - name: Install pycopm
-      run: |
         pip install -e .
+        pip install -r dev-requirements.txt
         
     - name: Check code style and linting 
       run: |
@@ -59,8 +63,8 @@ jobs:
 
     - name: Check if hello world example succeded
       run: |
-        file="/home/runner/work/pycopm/pycopm/output/HELLO_WORLD_PYCOPM.EGRID"
-        if [[ -f "$file" ]]; then
+        file="output/HELLO_WORLD_PYCOPM.EGRID"
+        if [ -f "$file" ]; then
           echo "pycopm succeeded"
         else
           echo "pycopm failed"
@@ -69,5 +73,5 @@ jobs:
         
     - name: Build documentation
       run: |
-        pushd docs
+        cd docs
         make html

--- a/src/pycopm/core/pycopm.py
+++ b/src/pycopm/core/pycopm.py
@@ -7,6 +7,7 @@
 import os
 import time
 import sys
+import shlex
 import argparse
 from io import StringIO
 import subprocess
@@ -396,20 +397,23 @@ def check_cmdargs(cmdargs):
         )
         sys.exit()
     if (cmdargs["input"].strip()).endswith(".DATA"):
-        if (
-            subprocess.call(
-                cmdargs["flow"].strip(),
-                shell=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-            )
-            != 1
-        ):
+        cmd = shlex.split(cmdargs["flow"].strip()) + ["-h"]
+        try:
+            if (
+                subprocess.run(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                ).returncode
+                != 0
+            ):
+                raise RuntimeError
+        except (FileNotFoundError, RuntimeError):
             print(
-                f"\nThe OPM flow executable '-f {cmdargs['flow'].strip()}' is not found, "
-                f"try to install it following the information in the documentation.\n"
+                f"\nThe OPM flow executable '-f {' '.join(cmd)}' is not available or not working.\n"
             )
-            sys.exit()
+            sys.exit(1)
         for option, flag in zip(["how", "nhow"], ["-a", "-n"]):
             if cmdargs[option].strip() not in ["min", "max", "mode"]:
                 print(

--- a/src/pycopm/utils/input_values.py
+++ b/src/pycopm/utils/input_values.py
@@ -8,6 +8,7 @@ Utiliy functions to set the input values from the toml configuration file.
 import csv
 import sys
 import tomllib
+import shlex
 import subprocess
 from itertools import islice
 import numpy as np
@@ -64,19 +65,22 @@ def check_flow(dic, in_file):
             "See the pycopm documentation.\n"
         )
         sys.exit()
-    flowtoml = subprocess.call(
-        dic["flowpth"].strip(),
-        shell=True,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.DEVNULL,
-    )
-    flowflag = subprocess.call(
-        dic["flowflag"],
-        shell=True,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.DEVNULL,
-    )
-    if flowtoml != 1 and flowflag != 1:
+
+    cmd1 = shlex.split(dic["flowpth"].strip()) + ["-h"]
+    cmd2 = shlex.split(dic["flowflag"]) + ["-h"]
+
+    def run(cmd):
+        try:
+            return subprocess.run(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, check=False
+            ).returncode
+        except FileNotFoundError:
+            return None
+
+    flowtoml = run(cmd1)
+    flowflag = run(cmd2)
+
+    if not (flowtoml == 0 or flowflag == 0):
         print(
             f"\nThe OPM flow executable '{dic['flowpth'].strip()}' is not found; "
             "try to install it following the pycopm documentation.\nIf it was "
@@ -85,14 +89,15 @@ def check_flow(dic, in_file):
             "(e.g., flow = '/home/pycopm/build/opm-simulators/bin/flow'),\n"
             "or using the command flag -f or --flow.\n"
         )
-        sys.exit()
-    if flowtoml != 1:
-        dic["flow"] = dic["flow"].split()
-        for i, value in enumerate(dic["flow"]):
+        sys.exit(1)
+
+    if flowtoml == 0:
+        parts = shlex.split(dic["flow"])
+        for i, value in enumerate(parts):
             if "flow" in value:
-                dic["flow"][i] = dic["flowflag"]
+                parts[i] = dic["flowflag"]
                 break
-        dic["flow"] = " ".join(dic["flow"])
+        dic["flow"] = " ".join(parts)
 
 
 def read_reference(dic):


### PR DESCRIPTION
## Description
This PR aims to fix the issue raised by @nasserma:
```
Traceback (most recent call last):
  File "/home/nasser/.local/bin/pycopm", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/nasser/.local/lib/python3.14/site-packages/pycopm/core/pycopm.py", line 454, in main
    pycopm()
    ~~~~~~^^
  File "/home/nasser/.local/lib/python3.14/site-packages/pycopm/core/pycopm.py", line 101, in pycopm
    process_input(dic, file)
    ~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/nasser/.local/lib/python3.14/site-packages/pycopm/utils/input_values.py", line 42, in process_input
    check_flow(dic, in_file)
    ~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/nasser/.local/lib/python3.14/site-packages/pycopm/utils/input_values.py", line 67, in check_flow
    flowtoml = subprocess.call(
        dic["flowpth"].strip(),
    ...<2 lines>...
        stdout=subprocess.DEVNULL,
    )
  File "/usr/lib/python3.14/subprocess.py", line 398, in call
    return p.wait(timeout=timeout)
           ~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/subprocess.py", line 1279, in wait
    return self._wait(timeout=timeout)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/subprocess.py", line 2084, in _wait
    (pid, sts) = self._try_wait(0)
                 ~~~~~~~~~~~~~~^^^
  File "/usr/lib/python3.14/subprocess.py", line 2042, in _try_wait
    (pid, sts) = os.waitpid(self.pid, wait_flags)
                 ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyboardInterrupt
```

PR part os the JOSS review https://github.com/openjournals/joss-reviews/issues/10124