### PR TITLE
Fixing explicitly passing the OPM Flow executable path

### DIFF
--- a/.github/workflows/ci_pycopm_macos.yml
+++ b/.github/workflows/ci_pycopm_macos.yml
@@ -11,6 +11,8 @@ jobs:
       contents: read
     timeout-minutes: 90
     runs-on: macos-26
+    env:
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
 
     steps:
     - uses: actions/checkout@v5

--- a/src/pycopm/core/pycopm.py
+++ b/src/pycopm/core/pycopm.py
@@ -20,10 +20,10 @@ from pycopm.utils.runs_executer import simulations, plotting
 from pycopm.utils.generate_files import create_deck
 
 
-def pycopm():
+def main(argv=None):
     """Main function for the pycopm executable"""
     start_time = time.monotonic()
-    cmdargs = load_parser()
+    cmdargs = load_parser(argv)
     check_cmdargs(cmdargs)
     file = cmdargs["input"].strip()  # Name of the input file
     dic = {"fol": os.path.abspath(cmdargs["output"])}  # Name for the output folder
@@ -140,7 +140,7 @@ def pycopm():
         plotting(dic, time.monotonic() - start_time)
 
 
-def load_parser():
+def load_parser(argv):
     """Argument options"""
     parser = argparse.ArgumentParser(
         description="Main script to tailor the geological model and run "
@@ -378,7 +378,7 @@ def load_parser():
         "add to the command ', vertical TF = 0', e.g., 'poro <= 0.1' (which includes vertical TF) "
         "or 'poro <= 0.1, vertical TF = 0' ('' by default)",
     )
-    return vars(parser.parse_known_args()[0])
+    return vars(parser.parse_known_args(argv)[0])
 
 
 def check_cmdargs(cmdargs):
@@ -453,8 +453,3 @@ def check_cmdargs(cmdargs):
         if cmdargs["displace"].strip() and cmdargs["gridding"].strip():
             print("\nInvalid combination, either set '-d' or '-g'.\n")
             sys.exit()
-
-
-def main():
-    """Main function"""
-    pycopm()

--- a/src/pycopm/utils/input_values.py
+++ b/src/pycopm/utils/input_values.py
@@ -75,7 +75,7 @@ def check_flow(dic, in_file):
                 cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, check=False
             ).returncode
         except FileNotFoundError:
-            return None
+            return 0
 
     flowtoml = run(cmd1)
     flowflag = run(cmd2)

--- a/tests/test_0_main.py
+++ b/tests/test_0_main.py
@@ -9,14 +9,14 @@ import shutil
 from pycopm.core.pycopm import main
 
 
-def test_0_main(tmp_path, monkeypatch):
+def test_0_main(flow, tmp_path, monkeypatch):
     """See examples/configurations/norne/input.toml"""
     monkeypatch.chdir(tmp_path)
     repo_root = Path(__file__).parents[1]
     input_config = repo_root / "examples" / "configurations" / "norne" / "input.toml"
     shutil.copy(input_config, tmp_path / "input.toml")
     monkeypatch.chdir(tmp_path)
-    main()
+    main(["-f", flow])
     assert (tmp_path / "postprocessing" / "errors.txt").is_file()
     assert (
         tmp_path / "postprocessing" / "wells" / "HISTO_DATA_WWPR_E-1H.png"


### PR DESCRIPTION
## Description
This brings back the possibility to pass the flow executable path via the `-f\--flow` flag, e.g., 
```bash
pytest --cov=pycopm --cov-report term-missing --basetemp=test_outputs --flow /Users/runner/work/OPM-Flow_macOS/OPM-Flow_macOS/build/opm-simulators/bin/flow tests/ -n auto
```

Bug spotted while giving maintenance to the repo [OPM-Flow_macOS](https://github.com/daavid00/OPM-Flow_macOS/blob/main/.github/workflows/ci_pycopm_macos.yml)